### PR TITLE
Feature/data definition patching fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ riderModule.iml
 .vs
 *.snk
 launchSettings.json
+.editorconfig

--- a/DistantWorlds2.ModLoader.Core/DataUtils.cs
+++ b/DistantWorlds2.ModLoader.Core/DataUtils.cs
@@ -32,7 +32,6 @@ public static class DataUtils
             var filePathChars = MemoryMarshal.AsBytes<char>(filePath.ToCharArray());
             hasher.Append(filePathChars);
             ComputeFileHash(hasher, filePath);
-            break;
         }
     }
 

--- a/DistantWorlds2.ModLoader.Core/GameDataDefinitionPatching.cs
+++ b/DistantWorlds2.ModLoader.Core/GameDataDefinitionPatching.cs
@@ -169,27 +169,28 @@ public static class GameDataDefinitionPatching
         }
     }
 
-    private static bool IsIndexedList<T>(T list)
+    private static bool IsIndexedList(object list)
     {
-        bool isIndexed;
-        if(IsIndexedListCache.TryGetValue(list.GetType(), out isIndexed))
+        var listType = list.GetType();
+        bool isIndexed;        
+        if (IsIndexedListCache.TryGetValue(listType, out isIndexed))
         {
             return isIndexed;
         }
-        var mi = list.GetType().GetMethod("RebuildIndexes", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var mi = listType.GetMethod("RebuildIndexes", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         if (mi != null)
         {
             var parameter = Expression.Parameter(typeof(object));
-            RebuildIndexMethods.Add(list.GetType(), Expression.Lambda<Action<object>>(
-                Expression.Call(Expression.Convert(parameter, list.GetType()),mi), parameter)
+            RebuildIndexMethods.Add(listType, Expression.Lambda<Action<object>>(
+                Expression.Call(Expression.Convert(parameter, listType),mi), parameter)
                 .CompileFast());
 
-            IsIndexedListCache[list.GetType()] = true;
+            IsIndexedListCache[listType] = true;
             return true;
         }
         else
         {
-            IsIndexedListCache[list.GetType()] = false;
+            IsIndexedListCache[listType] = false;
             return false;
         }
     }

--- a/DistantWorlds2.ModLoader.Core/GameDataDefinitionPatching.cs
+++ b/DistantWorlds2.ModLoader.Core/GameDataDefinitionPatching.cs
@@ -66,7 +66,7 @@ public static class GameDataDefinitionPatching
             new(nameof(CharacterAnimation), new(nameof(Galaxy.CharacterAnimationsStatic), () => Galaxy.CharacterAnimationsStatic, v => Galaxy.CharacterAnimationsStatic = (CharacterAnimationList)v)),
             new(nameof(CharacterRoom), new(nameof(Galaxy.CharacterRoomsStatic), () => Galaxy.CharacterRoomsStatic, v => Galaxy.CharacterRoomsStatic = (CharacterRoomList)v))
         });
-    
+
 
     private static readonly ImmutableSortedDictionary<string, StaticDefFieldInfo> LateStaticDefs
         = ImmutableSortedDictionary.CreateRange(
@@ -170,7 +170,7 @@ public static class GameDataDefinitionPatching
     }
 
     private static bool IsIndexedList<T>(T list)
-    {        
+    {
         bool isIndexed;
         if(IsIndexedListCache.TryGetValue(list.GetType(), out isIndexed))
         {
@@ -206,7 +206,7 @@ public static class GameDataDefinitionPatching
         if(IsIndexedList(list))
             RebuildIndexMethods[list.GetType()](list);
         else
-            throw new NotSupportedException();        
+            throw new NotSupportedException();
     }
 
     public static void RebuildIndices<T>(IList<T> list)
@@ -734,6 +734,7 @@ public static class GameDataDefinitionPatching
         var m = MiGenericPatchDefinitions.MakeGenericMethod(type);
         m.Invoke(null, new[] { defs, mods, idFieldName });
     }
+
     public static void GenericPatchDefinitions<T>(List<T> defs, YamlSequenceNode mods, string? idFieldName = null) where T : class
     {
         if (defs is null) throw new ArgumentNullException(nameof(defs));
@@ -983,7 +984,7 @@ public static class GameDataDefinitionPatching
                     }
                     break;
                 }
-                
+
                 case "template" when mod is YamlMappingNode item: {
 
                     var oldIdExpr = item.FirstOrDefault(kv => kv.Key is YamlScalarNode sk && sk.Value == idFieldName);
@@ -994,12 +995,12 @@ public static class GameDataDefinitionPatching
                         Console.Error.WriteLine($"Failed to parse {type.Name} @ {item.Start}");
                         break;
                     }
-                    
+
                     if (oldIdExpr.Value is not YamlScalarNode oldIdScalar) {
                         Console.Error.WriteLine($"Failed to parse {type.Name} @ {oldIdExpr.Value.Start}");
                         break;
                     }
-                    
+
                     if (newIdExpr.Value is not YamlScalarNode newIdScalar) {
                         Console.Error.WriteLine($"Failed to parse {type.Name} @ {newIdExpr.Value.Start}");
                         break;
@@ -1207,7 +1208,7 @@ public static class GameDataDefinitionPatching
 
                         ProcessObjectUpdate(type, def, item,
                             (_, expr) => Dsl.Parse(expr).CompileFast());
-                        
+
                         Console.WriteLine($"Updated {type.Name} {idVal}");
                     }
 
@@ -1303,6 +1304,7 @@ public static class GameDataDefinitionPatching
         var m = MiGenericPatchIndexedDefinitions.MakeGenericMethod(type);
         m.Invoke(null, new[] { defs, mods, idFieldName });
     }
+
     public static void GenericPatchIndexedDefinitions<T>(List<T> defs, YamlSequenceNode mods, string? idFieldName = null) where T : class
     {
         try
@@ -1380,6 +1382,7 @@ public static class GameDataDefinitionPatching
                 {
                     case IndexedList<T> indexed when id is int:
                         return indexed.GetIndex(ConvertToInt(id));
+
                     default:
                         MethodInfo mi = defs.GetType().GetMethod("GetIndex");
                         return (int)mi.Invoke(defs, new object[] { id });
@@ -1392,6 +1395,7 @@ public static class GameDataDefinitionPatching
                 {
                     case IndexedList<T> indexed:
                         return indexed.ContainsId(ConvertToInt(id));
+
                     default:
                         MethodInfo mi = defs.GetType().GetMethod("ContainsId");
                         return (bool)mi.Invoke(defs, new object[] { id });
@@ -1488,7 +1492,7 @@ public static class GameDataDefinitionPatching
                     case "test":
                         Console.Error.WriteLine($"Can't parse test instruction @ {mod.Start}");
                         break;
-                    
+
                     case "state" when mod is YamlMappingNode item: {
                         foreach (var kv in item)
                         {
@@ -1629,7 +1633,7 @@ public static class GameDataDefinitionPatching
                             break;
                         }
 
-                        var rawId = GetId(def);                        
+                        var rawId = GetId(def);
                         var contained = ContainsId(defs, rawId);
                         var id = ConvertToInt(rawId);
                         if (contained && defs[id] is not null)
@@ -1654,7 +1658,7 @@ public static class GameDataDefinitionPatching
                     case "add":
                         Console.Error.WriteLine($"Can't parse add instruction @ {mod.Start}");
                         break;
-                
+
                     case "template" when mod is YamlMappingNode item: {
 
                         var oldIdExpr = item.FirstOrDefault(kv => kv.Key is YamlScalarNode sk && sk.Value == idFieldName);
@@ -1665,12 +1669,12 @@ public static class GameDataDefinitionPatching
                             Console.Error.WriteLine($"Failed to parse {type.Name} @ {item.Start}");
                             break;
                         }
-                    
+
                         if (oldIdExpr.Value is not YamlScalarNode oldIdScalar) {
                             Console.Error.WriteLine($"Failed to parse {type.Name} @ {oldIdExpr.Value.Start}");
                             break;
                         }
-                    
+
                         if (newIdExpr.Value is not YamlScalarNode newIdScalar) {
                             Console.Error.WriteLine($"Failed to parse {type.Name} @ {newIdExpr.Value.Start}");
                             break;
@@ -1712,7 +1716,7 @@ public static class GameDataDefinitionPatching
                             var idLookupVar = idLookupVarNode.Value;
                             raw_id = ConvertToIdType(ModLoader.ModManager.SharedVariables.GetOrAdd(idLookupVar!, _ => GetRealNextId(defs)));
 
-                            item.Children.Remove(idLookupReq);                            
+                            item.Children.Remove(idLookupReq);
                         }
                         else
                         {
@@ -1860,6 +1864,7 @@ public static class GameDataDefinitionPatching
             }
         }
     }
+
     private static object ProcessObjectUpdate(Type type, object obj, YamlMappingNode item, Func<object, string, Func<object>> compileFn,
         IList? collection = null)
     {
@@ -2119,7 +2124,7 @@ public static class GameDataDefinitionPatching
             }
         }
         else
-            throw new NotImplementedException("Non-IList based collection.");       
+            throw new NotImplementedException("Non-IList based collection.");
     }
 
     private static void ParseCollectionUpdate(Type collectionType, ref IList collection, YamlMappingNode map,
@@ -2210,6 +2215,7 @@ public static class GameDataDefinitionPatching
             }
         }
     }
+
     private static object? ProcessCollectionItemUpdate(YamlNode valNode, Type itemType, object initValue,
         Func<object, string, Func<object>> compileFn, IList collection)
     {
@@ -2226,7 +2232,7 @@ public static class GameDataDefinitionPatching
             {
                 case YamlScalarNode scalar: {
                     var valStr = scalar.Value!;
-                    
+
                     /*
                      * x: # string[]
                      *  - a # <-- verbatim?

--- a/DistantWorlds2.ModLoader.Core/GameDataDefinitionPatching.cs
+++ b/DistantWorlds2.ModLoader.Core/GameDataDefinitionPatching.cs
@@ -152,20 +152,20 @@ public static class GameDataDefinitionPatching
 
     public static void ApplyContentPatches()
     {
-            foreach (var dataPath in ModLoader.ModManager.PatchedDataStack)
+        foreach (var dataPath in ModLoader.ModManager.PatchedDataStack)
+        {
+            try
             {
-                try
-                {
-                    if (ModLoader.DebugMode)
-                        Console.WriteLine($"Applying content patches from {dataPath}");
-                    GameDataDefinitionPatching.ApplyContentPatches(dataPath);
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"Failure applying content patches from {dataPath}");
-                    ModLoader.ModManager.OnUnhandledException(ExceptionDispatchInfo.Capture(ex));
-                }
+                if (ModLoader.DebugMode)
+                    Console.WriteLine($"Applying content patches from {dataPath}");
+                ApplyContentPatches(dataPath);
             }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failure applying content patches from {dataPath}");
+                ModLoader.ModManager.OnUnhandledException(ExceptionDispatchInfo.Capture(ex));
+            }
+        }
     }
 
     public static bool IsIndexedList(IList list)
@@ -190,7 +190,7 @@ public static class GameDataDefinitionPatching
             {
                 if (ModLoader.DebugMode)
                     Console.WriteLine($"Applying content patches from {dataPath}");
-                ApplyDynamicContentPatches(dataPath, galaxy);
+                ApplyLateContentPatches(dataPath);
             }
             catch (Exception ex)
             {
@@ -242,7 +242,6 @@ public static class GameDataDefinitionPatching
             }
         }
     }
-
 
     public static void ApplyDynamicContentPatches(string dataPath, Galaxy galaxy)
     {
@@ -308,7 +307,7 @@ public static class GameDataDefinitionPatching
 
                         if (GalaxyDefs.TryGetValue(typeStr, out var getGlxDef))
                         {
-                            var def = getGlxDef(galaxy);
+                            var def = getGlxDef.Get(galaxy);
                             PatchDynamicDefinition(type, def, valueSeq);
                             continue;
                         }
@@ -317,7 +316,7 @@ public static class GameDataDefinitionPatching
                         {
                             foreach (var e in galaxy.Empires)
                             {
-                                var def = getEmpDef(e);
+                                var def = getEmpDef.Get(e);
                                 Dsl["empire"] = e;
                                 PatchDynamicDefinition(type, def, valueSeq);
                             }

--- a/DistantWorlds2.ModLoader.Core/GameDataUtils.cs
+++ b/DistantWorlds2.ModLoader.Core/GameDataUtils.cs
@@ -29,7 +29,7 @@ public static class GameDataUtils
             _ => throw new NotImplementedException()
         };
 
-    public static object? GetValue(object obj, MemberInfo m)
+    public static object? GetValue(object? obj, MemberInfo m)
         => m switch
         {
             FieldInfo fi => fi.GetValue(obj),
@@ -53,7 +53,7 @@ public static class GameDataUtils
             _ => throw new NotImplementedException()
         };
     
-    public static void SetValue(object obj, MemberInfo m, object? value)
+    public static void SetValue(object? obj, MemberInfo m, object? value)
     {
         switch (m)
         {

--- a/DistantWorlds2.ModLoader.Core/IDefFieldInfo.cs
+++ b/DistantWorlds2.ModLoader.Core/IDefFieldInfo.cs
@@ -1,0 +1,7 @@
+namespace DistantWorlds2.ModLoader;
+
+interface IDefFieldInfo {
+
+  public string FieldName { get; }
+
+}

--- a/DistantWorlds2.ModLoader.Core/IModManager.cs
+++ b/DistantWorlds2.ModLoader.Core/IModManager.cs
@@ -20,7 +20,7 @@ public interface IModManager
 
     ConcurrentDictionary<string, object> SharedVariables { get; }
 
-    public string Checksum { get; }
+    public string GameDataChecksum { get; }
 
     void AddScoped(Type type, Func<IServiceProvider, object> factory);
 

--- a/DistantWorlds2.ModLoader.Core/IModManager.cs
+++ b/DistantWorlds2.ModLoader.Core/IModManager.cs
@@ -20,6 +20,8 @@ public interface IModManager
 
     ConcurrentDictionary<string, object> SharedVariables { get; }
 
+    public string Checksum { get; }
+
     void AddScoped(Type type, Func<IServiceProvider, object> factory);
 
     void AddSingleton(Type type, Func<IServiceProvider, object> factory);

--- a/DistantWorlds2.ModLoader.Core/IStaticDefFieldInfo.cs
+++ b/DistantWorlds2.ModLoader.Core/IStaticDefFieldInfo.cs
@@ -1,0 +1,9 @@
+namespace DistantWorlds2.ModLoader;
+
+interface IStaticDefFieldInfo : IDefFieldInfo {
+
+  public Func<object> Get { get; }
+
+  public Action<object> Set { get; }
+
+}

--- a/DistantWorlds2.ModLoader.Core/InstanceDefFieldInfo.cs
+++ b/DistantWorlds2.ModLoader.Core/InstanceDefFieldInfo.cs
@@ -1,0 +1,17 @@
+namespace DistantWorlds2.ModLoader;
+
+public class InstanceDefFieldInfo<T> : IDefFieldInfo {
+
+  public string FieldName { get; }
+
+  public Func<T, object> Get { get; }
+
+  public Action<T, object> Set { get; }
+
+  public InstanceDefFieldInfo(string fieldName, Func<T, object> get, Action<T, object> set) {
+    FieldName = fieldName;
+    Get = get;
+    Set = set;
+  }
+
+}

--- a/DistantWorlds2.ModLoader.Core/StaticDefFieldInfo.cs
+++ b/DistantWorlds2.ModLoader.Core/StaticDefFieldInfo.cs
@@ -1,0 +1,17 @@
+namespace DistantWorlds2.ModLoader;
+
+public class StaticDefFieldInfo : IStaticDefFieldInfo {
+
+  public string FieldName { get; }
+
+  public Func<object> Get { get; }
+
+  public Action<object> Set { get; }
+
+  public StaticDefFieldInfo(string fieldName, Func<object> get, Action<object> set) {
+    FieldName = fieldName;
+    Get = get;
+    Set = set;
+  }
+
+}

--- a/DistantWorlds2.ModLoader.ModManager/ModInfo.cs
+++ b/DistantWorlds2.ModLoader.ModManager/ModInfo.cs
@@ -15,7 +15,7 @@ namespace DistantWorlds2.ModLoader;
 [PublicAPI]
 public class ModInfo : IModInfo
 {
-    public static Type HasherType = typeof(XxHash64); // typeof(Crc64);
+    public static Type HasherType = typeof(Crc64); //TODO: Switch back to XxHash64 once https://github.com/dotnet/runtime/issues/69184 is resolved and released.
 
     public string Name { get; }
     public string Dir { get; }

--- a/DistantWorlds2.ModLoader.ModManager/ModManager.cs
+++ b/DistantWorlds2.ModLoader.ModManager/ModManager.cs
@@ -31,7 +31,7 @@ public class ModManager : IModManager {
 
   private string? _modsDir;
 
-  private byte[]? _checksum;
+  private byte[]? _gameDataChecksum;
 
   private IEnumerable<IModInfo>? _loadOrder;
 
@@ -635,9 +635,9 @@ public class ModManager : IModManager {
     return checksumHasher.GetCurrentHash();
   }
 
-  public string Checksum {
+  public string GameDataChecksum {
     get {
-      return (_checksum ??= CalculateGameDataChecksum()).ToHexString();
+      return (_gameDataChecksum ??= CalculateGameDataChecksum()).ToHexString();
     }
   }
 

--- a/DistantWorlds2.ModLoader.ModManager/ModManager.cs
+++ b/DistantWorlds2.ModLoader.ModManager/ModManager.cs
@@ -329,7 +329,7 @@ public class ModManager : IModManager {
         // TODO: log
       }
 
-    _loadOrder = Mods.Values.Where(m => m.IsValid)      
+    _loadOrder = Mods.Values.Where(m => m.IsValid)
       .OrderByDescending(m => m.LoadPriority)
       .ThenByDescending(m => m.Name)
       .StableOrderTopologicallyBy(ModInfo.GetResolvedDependencies);
@@ -345,7 +345,7 @@ public class ModManager : IModManager {
         OnUnhandledException(edi);
       }
     }
-    
+
     foreach (var overrideAssetsPath in OverrideAssetsStack) {
       try {
         if (ModLoader.DebugMode)
@@ -660,7 +660,7 @@ public class ModManager : IModManager {
       AddSingleton(system.GetType(), system);
 
         if (ModLoader.DebugMode)
-    GameDataDefinitionPatching.ApplyContentPatches();    
+    GameDataDefinitionPatching.ApplyContentPatches();
   }
 
   public void UnloadContent() {

--- a/DistantWorlds2.ModLoader.Patches/PatchGalaxy.cs
+++ b/DistantWorlds2.ModLoader.Patches/PatchGalaxy.cs
@@ -13,6 +13,13 @@ namespace DistantWorlds2.ModLoader;
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 public static class PatchGalaxy
 {
+    [HarmonyPatch(nameof(Galaxy.LoadApplyStaticBaseDataVariable))]
+    [HarmonyPostfix]
+    public static void PostfixLoadApplyStaticBaseDataVariable(Galaxy galaxy)
+    {
+        GameDataDefinitionPatching.ApplyLateContentPatches(galaxy);
+    }
+
     [HarmonyPatch(nameof(Galaxy.Generate))]
     [HarmonyPrefix]
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -21,26 +28,6 @@ public static class PatchGalaxy
     {
         if (!ModLoader.MaybeWaitForLoaded()) return;
 
-        foreach (var dataPath in ModLoader.ModManager.PatchedDataStack)
-        {
-            try
-            {
-                if (ModLoader.DebugMode)
-                    Console.WriteLine($"Applying content patches from {dataPath}");
-                GameDataDefinitionPatching.ApplyContentPatches(dataPath, __instance);
-            }
-            catch (Exception ex)
-            {
-                try
-                {
-                    Console.Error.WriteLine($"Failure applying content patches from {dataPath}");
-                    ModLoader.ModManager.OnUnhandledException(ExceptionDispatchInfo.Capture(ex));
-                }
-                catch
-                {
-                    Console.Error.WriteLine("Failure reporting exception.");
-                }
-            }
-        }
+        GameDataDefinitionPatching.ApplyDynamicDefinitions(__instance);
     }
 }


### PR DESCRIPTION
Fixes #8 (multiple patch execution)

Adds reflection as a fallback to detect "indexed" lists which don't inherit from IndexedList<T>.

Caches patched static definitions between runs, to avoid slow patching.